### PR TITLE
async popup stealing focus on window activations

### DIFF
--- a/windowPreview.js
+++ b/windowPreview.js
@@ -109,7 +109,7 @@ const thumbnailPreviewMenu = new Lang.Class({
         this.shouldOpen = true;
         this.shouldClose = false;
 
-        Mainloop.timeout_add(Taskbar.DASH_ITEM_HOVER_TIMEOUT, Lang.bind(this, this.hoverOpen));
+        this.hoverOpen();
     },
 
     _onMenuLeave: function () {
@@ -122,7 +122,7 @@ const thumbnailPreviewMenu = new Lang.Class({
         this.shouldOpen = true;
         this.shouldClose = false;
 
-        Mainloop.timeout_add(Taskbar.DASH_ITEM_HOVER_TIMEOUT, Lang.bind(this, this.hoverOpen));
+        this.hoverOpen();
     },
 
     _onLeave: function () {


### PR DESCRIPTION
When switching apps, sometimes the hover popup would activate after the new window was activated, partially stealing focus and leaving new window in a frozen state. Unfortunately I couldn't get this working async to debounce quick mouseovers of the icon. I've only observed in X11 so the previous implementation may be ok in Wayland.